### PR TITLE
Failed asserting that 0.1.1 module version is equal to 0.1.1.

### DIFF
--- a/src/app/code/community/FireGento/Customer/Test/Config/Main/expectations/testModuleConfig.yaml
+++ b/src/app/code/community/FireGento/Customer/Test/Config/Main/expectations/testModuleConfig.yaml
@@ -1,5 +1,5 @@
 module:
-  version: 0.1.1
+  version: 1.0.0
   code_pool: community
   depends:
     - Mage_Customer


### PR DESCRIPTION
Running PHPUnit on FireGento_Customer v1.0.0 fails:

```
1) FireGento_Customer_Test_Config_Main::testModuleConfig
Failed asserting that 0.1.1 module version is equal to 0.1.1.
--- Expected
+++ Actual
@@ @@
-'0.1.1'
+'1.0.0'
```

My commit fixes the expectation.
